### PR TITLE
Fixed close/hide window at start bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const THIS_VERSION = '1.5.4'
 
 document.addEventListener('DOMContentLoaded', function () {
 
-    var activeWindowId = window.initialWindowId
+    var activeWindowId = window.location.search.substr(1)
     var peekATabWindowId = null
     var closeOnFocusChange = true
 

--- a/popup.js
+++ b/popup.js
@@ -15,12 +15,16 @@ document.addEventListener('DOMContentLoaded', function () {
         browser.windows.getCurrent(function (win) {
             browser.tabs.query({windowId: win.id, active: true}, function (tabs) {
                 var tab = tabs[0];
-                popupWindow = window.open(
-                    browser.extension.getURL("app.html"),
-                    "Tabs you can peek at",
-                    "alwaysOnTop=yes,width=" + width + ",height=" + (win.height - 10) + ",left=" + window.screenLeft + ",top=" + (window.screenTop - 70)
-                );
-                popupWindow.initialWindowId = win.id;
+                
+                chrome.windows.create({
+					'url': browser.runtime.getURL("app.html") + "?" + win.id,
+					'type': 'popup',
+					'focused': true,
+					'width': width,
+					'height': (win.height - 10),
+					'left': window.screenLeft,
+					'top': (window.screenTop - 70)
+				});
 
                 window.close(); // close the Chrome extension pop-up
             });


### PR DESCRIPTION
Changed popup window create code from vanilla JS to using Chrome Extension API. This didn't allow passing of variables to the new window, so I'm simply passing it as a GET parameter which is then fetched in the popup window code.